### PR TITLE
Rename for npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "plugin-coffee",
+  "name": "system-coffee",
   "version": "1.8.0",
   "description": "SystemJS plugin for CoffeeScript",
   "main": "coffee.js",


### PR DESCRIPTION
https://www.npmjs.com/package/system-coffee

I'm guessing you're forresto on npmjs.org? I added you as an owner to the package.

@guybedford `system-` is a nice prefix. :+1: `plugin-` is a bit generic. The `system-` ones could be unpublished though, if needed, but really I was just pushing for them to be on npmjs in some form or other.
